### PR TITLE
feat: enhance CAE mesh and result node picking

### DIFF
--- a/resource/icon/cae_demo_analysis.svg
+++ b/resource/icon/cae_demo_analysis.svg
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><defs><style>.a{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path class="a" d="M39.5,15.5h-9a2,2,0,0,1-2-2v-9h-18a2,2,0,0,0-2,2v35a2,2,0,0,0,2,2h27a2,2,0,0,0,2-2Z"/><line class="a" x1="28.5" y1="4.5" x2="39.5" y2="15.5"/></svg>

--- a/resource/icon/cae_pick_node.svg
+++ b/resource/icon/cae_pick_node.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><defs><style>.a{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path class="a" d="M39.5,15.5h-9a2,2,0,0,1-2-2v-9h-18a2,2,0,0,0-2,2v35a2,2,0,0,0,2,2h27a2,2,0,0,0,2-2Z"/><line class="a" x1="28.5" y1="4.5" x2="39.5" y2="15.5"/></svg>

--- a/resource/icon/cae_result_probe.svg
+++ b/resource/icon/cae_result_probe.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><defs><style>.a{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;}</style></defs><path class="a" d="M39.5,15.5h-9a2,2,0,0,1-2-2v-9h-18a2,2,0,0,0-2,2v35a2,2,0,0,0,2,2h27a2,2,0,0,0,2-2Z"/><line class="a" x1="28.5" y1="4.5" x2="39.5" y2="15.5"/></svg>

--- a/resource/resource.qrc
+++ b/resource/resource.qrc
@@ -64,13 +64,14 @@
         <file>icon/animation.svg</file>
         <file>icon/busbar.svg</file>
         <file>icon/cae_assign_material.svg</file>
-        <file>icon/cae_demo_analysis.svg</file>
         <file>icon/cae_deformation_scale.svg</file>
         <file>icon/cae_fixed_support.svg</file>
         <file>icon/cae_force.svg</file>
         <file>icon/cae_generate_mesh.svg</file>
         <file>icon/cae_named_selection.svg</file>
+        <file>icon/cae_pick_node.svg</file>
         <file>icon/cae_result_displacement.svg</file>
+        <file>icon/cae_result_probe.svg</file>
         <file>icon/cae_result_stress.svg</file>
         <file>icon/cae_result_temperature.svg</file>
         <file>icon/cae_run_solver.svg</file>

--- a/src/cae/CaeController.cpp
+++ b/src/cae/CaeController.cpp
@@ -142,7 +142,7 @@ QString CaeController::generateMesh(const QString& geometryFilePath, double glob
     }
 
     if (globalSize <= 0.0) {
-        return QStringLiteral("Global mesh size must be greater than zero.");
+        return QStringLiteral("Maximum element size must be greater than zero.");
     }
 
     const CaeMeshSetup setup(globalSize, MeshElementOrder::First);
@@ -153,7 +153,12 @@ QString CaeController::generateMesh(const QString& geometryFilePath, double glob
         return errorMessage;
     }
 
-    study->setMesh(CaeMesh(setup, meshResult.nodeCount, meshResult.elementCount, meshResult.meshFilePath));
+    study->setMesh(CaeMesh(
+        setup,
+        meshResult.nodeCount,
+        meshResult.surfaceElementCount,
+        meshResult.volumeElementCount,
+        meshResult.meshFilePath));
     study->setState(StudyState::Meshed);
     return QStringLiteral("Mesh setup prepared for %1 by %2: size=%3, order=%4.")
         .arg(study->name())
@@ -254,36 +259,6 @@ QString CaeController::showResult(ResultFieldType fieldType)
         std::move(resultField.nodalDisplacements)));
 
     return QStringLiteral("Result field prepared: %1.").arg(toDisplayString(fieldType));
-}
-
-QString CaeController::runDemoAnalysis(bool hasGeometry, const QString& geometryFilePath)
-{
-    createStudy(StudyType::StaticStructural);
-
-    QString message = useCurrentGeometry(hasGeometry);
-    if (m_project->activeStudy()->state() != StudyState::GeometryReady) {
-        return message;
-    }
-
-    createDefaultNamedSelection();
-    assignDefaultMaterial();
-    addFixedSupport();
-    addDefaultForce();
-
-    message = generateMesh(geometryFilePath);
-    if (m_project->activeStudy()->state() == StudyState::Failed) {
-        return message;
-    }
-
-    message = runSolver();
-    if (m_project->activeStudy()->state() == StudyState::Failed) {
-        return message;
-    }
-
-    showResult(ResultFieldType::Displacement);
-    showResult(ResultFieldType::VonMisesStress);
-    return QStringLiteral("Demo static CAE analysis completed with %1 and %2.")
-        .arg(m_services.meshGenerator->name(), m_services.solver->name());
 }
 
 QString CaeController::summary() const

--- a/src/cae/CaeController.h
+++ b/src/cae/CaeController.h
@@ -30,7 +30,6 @@ public:
     QString generateMesh(const QString& geometryFilePath = QString(), double globalSize = 1.0);
     QString runSolver();
     QString showResult(ResultFieldType fieldType);
-    QString runDemoAnalysis(bool hasGeometry = true, const QString& geometryFilePath = QString());
     QString summary() const;
 
     CaeProject& project();

--- a/src/cae/CaeDummyServices.cpp
+++ b/src/cae/CaeDummyServices.cpp
@@ -18,7 +18,8 @@ bool DummyMeshGenerator::generate(const MeshRequest& request, MeshResult* result
 
     result->meshFilePath = QStringLiteral("dummy://mesh/global-size-%1").arg(request.globalSize);
     result->nodeCount = 125;
-    result->elementCount = 384;
+    result->surfaceElementCount = 96;
+    result->volumeElementCount = 288;
     return true;
 }
 

--- a/src/cae/CaeGmshMeshGenerator.cpp
+++ b/src/cae/CaeGmshMeshGenerator.cpp
@@ -1,9 +1,9 @@
 #include "CaeGmshMeshGenerator.h"
 
+#include "CaeMsh2Reader.h"
+
 #include <QDir>
-#include <QFile>
 #include <QFileInfo>
-#include <QTextStream>
 
 #include <utility>
 
@@ -81,30 +81,21 @@ bool GmshMeshGenerator::readMeshStatistics(
     MeshResult* result,
     QString* errorMessage) const
 {
-    QFile meshFile(meshFilePath);
-    if (!meshFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    Msh2MeshData meshData;
+    if (!Msh2Reader::read(meshFilePath, &meshData, errorMessage)) {
+        return false;
+    }
+
+    if (meshData.volumeElements.empty()) {
         if (errorMessage) {
-            *errorMessage = QStringLiteral("Gmsh did not produce a readable mesh file: %1").arg(meshFilePath);
+            *errorMessage = QStringLiteral("Gmsh mesh contains no supported volume elements: %1").arg(meshFilePath);
         }
         return false;
     }
 
-    QTextStream stream(&meshFile);
-    while (!stream.atEnd()) {
-        const QString line = stream.readLine().trimmed();
-        if (line == QStringLiteral("$Nodes") && !stream.atEnd()) {
-            result->nodeCount = stream.readLine().trimmed().toInt();
-        } else if (line == QStringLiteral("$Elements") && !stream.atEnd()) {
-            result->elementCount = stream.readLine().trimmed().toInt();
-        }
-    }
-
-    if (result->nodeCount <= 0 || result->elementCount <= 0) {
-        if (errorMessage) {
-            *errorMessage = QStringLiteral("Gmsh mesh contains no nodes or elements: %1").arg(meshFilePath);
-        }
-        return false;
-    }
+    result->nodeCount = static_cast<int>(meshData.nodes.size());
+    result->surfaceElementCount = static_cast<int>(meshData.surfaceElements.size());
+    result->volumeElementCount = static_cast<int>(meshData.volumeElements.size());
     return true;
 }
 

--- a/src/cae/CaeMesh.cpp
+++ b/src/cae/CaeMesh.cpp
@@ -20,10 +20,16 @@ MeshElementOrder CaeMeshSetup::elementOrder() const
     return m_elementOrder;
 }
 
-CaeMesh::CaeMesh(CaeMeshSetup setup, int nodeCount, int elementCount, QString source)
+CaeMesh::CaeMesh(
+    CaeMeshSetup setup,
+    int nodeCount,
+    int surfaceElementCount,
+    int volumeElementCount,
+    QString source)
     : m_setup(std::move(setup))
     , m_nodeCount(nodeCount)
-    , m_elementCount(elementCount)
+    , m_surfaceElementCount(surfaceElementCount)
+    , m_volumeElementCount(volumeElementCount)
     , m_source(std::move(source))
 {
 }
@@ -40,7 +46,17 @@ int CaeMesh::nodeCount() const
 
 int CaeMesh::elementCount() const
 {
-    return m_elementCount;
+    return m_surfaceElementCount + m_volumeElementCount;
+}
+
+int CaeMesh::surfaceElementCount() const
+{
+    return m_surfaceElementCount;
+}
+
+int CaeMesh::volumeElementCount() const
+{
+    return m_volumeElementCount;
 }
 
 QString CaeMesh::source() const

--- a/src/cae/CaeMesh.h
+++ b/src/cae/CaeMesh.h
@@ -23,17 +23,25 @@ private:
 
 class CaeMesh {
 public:
-    CaeMesh(CaeMeshSetup setup, int nodeCount, int elementCount, QString source);
+    CaeMesh(
+        CaeMeshSetup setup,
+        int nodeCount,
+        int surfaceElementCount,
+        int volumeElementCount,
+        QString source);
 
     const CaeMeshSetup& setup() const;
     int nodeCount() const;
     int elementCount() const;
+    int surfaceElementCount() const;
+    int volumeElementCount() const;
     QString source() const;
 
 private:
     CaeMeshSetup m_setup;
     int m_nodeCount{0};
-    int m_elementCount{0};
+    int m_surfaceElementCount{0};
+    int m_volumeElementCount{0};
     QString m_source;
 };
 

--- a/src/cae/CaeResult.cpp
+++ b/src/cae/CaeResult.cpp
@@ -58,6 +58,23 @@ const std::map<int, std::array<double, 3>>& CaeResultField::nodalDisplacements()
     return m_nodalDisplacements;
 }
 
+std::optional<CaeResultProbe> CaeResultField::probeNode(int nodeId) const
+{
+    const auto value = m_nodalValues.find(nodeId);
+    if (value == m_nodalValues.end()) {
+        return std::nullopt;
+    }
+
+    CaeResultProbe probe;
+    probe.nodeId = nodeId;
+    probe.value = value->second;
+    const auto displacement = m_nodalDisplacements.find(nodeId);
+    if (displacement != m_nodalDisplacements.end()) {
+        probe.displacement = displacement->second;
+    }
+    return probe;
+}
+
 void CaeResult::addOrReplaceField(CaeResultField field)
 {
     const auto existing = std::find_if(

--- a/src/cae/CaeResult.h
+++ b/src/cae/CaeResult.h
@@ -5,9 +5,16 @@
 #include <QString>
 #include <array>
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace Cae {
+
+struct CaeResultProbe {
+    int nodeId{0};
+    double value{0.0};
+    std::optional<std::array<double, 3>> displacement;
+};
 
 class CaeResultField {
 public:
@@ -27,6 +34,7 @@ public:
     QString source() const;
     const std::map<int, double>& nodalValues() const;
     const std::map<int, std::array<double, 3>>& nodalDisplacements() const;
+    std::optional<CaeResultProbe> probeNode(int nodeId) const;
 
 private:
     ResultFieldType m_type{ResultFieldType::Displacement};

--- a/src/cae/CaeServiceInterfaces.h
+++ b/src/cae/CaeServiceInterfaces.h
@@ -26,7 +26,8 @@ struct SolverRequest {
 struct MeshResult {
     QString meshFilePath;
     int nodeCount{0};
-    int elementCount{0};
+    int surfaceElementCount{0};
+    int volumeElementCount{0};
 };
 
 struct SolverResult {

--- a/src/display/OCCView.cpp
+++ b/src/display/OCCView.cpp
@@ -334,6 +334,10 @@ void OCCView::keyPressEvent(QKeyEvent *theEvent)
 
 void OCCView::mousePressEvent(QMouseEvent *theEvent)
 {
+    if (theEvent->button() == Qt::LeftButton) {
+        emit signalViewportClicked(theEvent->pos().x(), theEvent->pos().y());
+    }
+
     if (m_mouseMode == View::SELECTION) {
         // Check manipulator intersection first when in SELECTION mode
         if (!m_manipulator.IsNull() && m_manipulator->HasActiveMode()) {
@@ -438,6 +442,8 @@ void OCCView::mouseDoubleClickEvent(QMouseEvent *event)
 
 void OCCView::mouseMoveEvent(QMouseEvent *theEvent)
 {
+    emit signalViewportMouseMoved(theEvent->pos().x(), theEvent->pos().y());
+
     if (m_mouseMode == View::MANIPULATING && !m_manipulator.IsNull())
     {
         m_manipulator->Transform(theEvent->pos().x(), theEvent->pos().y(), m_view);

--- a/src/display/OCCView.h
+++ b/src/display/OCCView.h
@@ -102,6 +102,8 @@ signals:
     void signalSelectedObjects(const std::vector<std::shared_ptr<View::SelectedEntity>>& selectedObjects);
     void signalManipulatorChange(const gp_Trsf& trsf);
     void signalMouseMove(double x, double y, double z);
+    void signalViewportMouseMoved(int x, int y);
+    void signalViewportClicked(int x, int y);
 public:
     //! Main constructor.
     OCCView(QWidget *theParent = nullptr);

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -16,6 +16,8 @@
 #include <QStatusBar>
 #include <QLabel>
 #include <QInputDialog>
+#include <QMessageBox>
+#include <QSignalBlocker>
 #include <QTabWidget>
 
 // Note: TopoDS_Shape and TopAbs_ShapeEnum are available through ViewerWidget.h includes
@@ -62,6 +64,7 @@ MainWindow::MainWindow(QWidget* parent) : SARibbonMainWindow(parent)
     connect(m_modelTreeWidget, &ModelTreeWidget::labelSelected,      m_viewerWidget, &ViewerWidget::highlightLabel);
     connect(m_modelTreeWidget, &ModelTreeWidget::labelPickRequested, m_viewerWidget, &ViewerWidget::highlightLabel);
     connect(m_modelTreeWidget, &ModelTreeWidget::labelRemoveRequested, m_viewerWidget, &ViewerWidget::removeLabelShape);
+    connect(m_viewerWidget, &ViewerWidget::signalCaeNodePicked, this, &MainWindow::onCaeNodePicked);
 
     setCentralWidget( splitter );
     refreshCaeTree();
@@ -594,10 +597,6 @@ void MainWindow::createCaeGroup()
     connect(m_caeNewThermalAction, &QAction::triggered, this, &MainWindow::onCaeNewThermalStudy);
     m_caeStudyPannel->addLargeAction(m_caeNewThermalAction);
 
-    m_caeRunDemoAnalysisAction = new QAction(QIcon(":/icons/icon/cae_demo_analysis.svg"), tr("Demo Analysis"), this);
-    connect(m_caeRunDemoAnalysisAction, &QAction::triggered, this, &MainWindow::onCaeRunDemoAnalysis);
-    m_caeStudyPannel->addLargeAction(m_caeRunDemoAnalysisAction);
-
     m_caeGeometryPannel = m_caeCategory->addPannel(tr("Geometry"));
     m_caeUseCurrentGeometryAction = new QAction(QIcon(":/icons/icon/cae_use_current_geometry.svg"), tr("Use Current"), this);
     connect(m_caeUseCurrentGeometryAction, &QAction::triggered, this, &MainWindow::onCaeUseCurrentGeometry);
@@ -647,6 +646,15 @@ void MainWindow::createCaeGroup()
     m_caeDeformationScaleAction = new QAction(QIcon(":/icons/icon/cae_deformation_scale.svg"), tr("Deformation Scale"), this);
     connect(m_caeDeformationScaleAction, &QAction::triggered, this, &MainWindow::onCaeSetDeformationScale);
     m_caeResultsPannel->addSmallAction(m_caeDeformationScaleAction);
+
+    m_caeProbeResultAction = new QAction(QIcon(":/icons/icon/cae_result_probe.svg"), tr("Probe"), this);
+    connect(m_caeProbeResultAction, &QAction::triggered, this, &MainWindow::onCaeProbeResult);
+    m_caeResultsPannel->addSmallAction(m_caeProbeResultAction);
+
+    m_caePickNodeAction = new QAction(QIcon(":/icons/icon/cae_pick_node.svg"), tr("Pick Node"), this);
+    m_caePickNodeAction->setCheckable(true);
+    connect(m_caePickNodeAction, &QAction::toggled, this, &MainWindow::onCaePickNodeToggled);
+    m_caeResultsPannel->addSmallAction(m_caePickNodeAction);
 
     m_caeSettingsPannel = m_caeCategory->addPannel(tr("Settings"));
     m_caeSettingsAction = new QAction(QIcon(":/icons/icon/cae_settings.svg"), tr("Settings"), this);
@@ -1012,6 +1020,7 @@ void MainWindow::onShapeToolHole()
 
 void MainWindow::onCaeNewStaticStudy()
 {
+    m_caePickNodeAction->setChecked(false);
     m_currentCaeResultField.reset();
     m_viewerWidget->clearScalarField();
     m_viewerWidget->clearCaeMesh();
@@ -1021,6 +1030,7 @@ void MainWindow::onCaeNewStaticStudy()
 
 void MainWindow::onCaeNewThermalStudy()
 {
+    m_caePickNodeAction->setChecked(false);
     m_currentCaeResultField.reset();
     m_viewerWidget->clearScalarField();
     m_viewerWidget->clearCaeMesh();
@@ -1028,40 +1038,9 @@ void MainWindow::onCaeNewThermalStudy()
     refreshCaeTree();
 }
 
-void MainWindow::onCaeRunDemoAnalysis()
-{
-    m_currentCaeResultField.reset();
-    QString geometryFilePath;
-    const Cae::CaeExternalToolConfig& config = m_caeController->externalToolConfig();
-    if (config.hasExecutablePath(Cae::ExternalTool::Gmsh) && m_viewerWidget->hasGeometry()) {
-        QString workingDirectory = config.workingDirectory();
-        if (workingDirectory.isEmpty()) {
-            workingDirectory = QDir::temp().filePath(QStringLiteral("Qt_OCC_CAE"));
-        }
-        if (!QDir().mkpath(workingDirectory)) {
-            updateStatusMessage(tr("Failed to create CAE working directory: %1").arg(workingDirectory), 8000);
-            return;
-        }
-        geometryFilePath = QDir(workingDirectory).filePath(QStringLiteral("cae_geometry.step"));
-        QString exportError;
-        if (!m_viewerWidget->exportCaeGeometry(geometryFilePath, &exportError)) {
-            updateStatusMessage(exportError, 8000);
-            return;
-        }
-    }
-
-    updateStatusMessage(
-        m_caeController->runDemoAnalysis(m_viewerWidget->hasGeometry(), geometryFilePath),
-        8000);
-    refreshCaeTree();
-    const Cae::CaeStudy* study = m_caeController->project().activeStudy();
-    if (study && study->state() == Cae::StudyState::Solved) {
-        presentCaeResult(Cae::ResultFieldType::VonMisesStress);
-    }
-}
-
 void MainWindow::onCaeUseCurrentGeometry()
 {
+    m_caePickNodeAction->setChecked(false);
     m_currentCaeResultField.reset();
     m_viewerWidget->clearScalarField();
     m_viewerWidget->clearCaeMesh();
@@ -1122,6 +1101,9 @@ void MainWindow::onCaeAddForce()
 
 void MainWindow::resetCaeResultPresentation(bool preserveMesh)
 {
+    if (m_caePickNodeAction) {
+        m_caePickNodeAction->setChecked(false);
+    }
     m_currentCaeResultField.reset();
     m_viewerWidget->clearScalarField();
 
@@ -1142,7 +1124,7 @@ void MainWindow::onCaeGenerateMesh()
     const double globalSize = QInputDialog::getDouble(
         this,
         tr("Generate CAE Mesh"),
-        tr("Global element size:"),
+        tr("Maximum element size:"),
         m_caeGlobalMeshSize,
         1.0e-6,
         1.0e9,
@@ -1152,6 +1134,7 @@ void MainWindow::onCaeGenerateMesh()
         return;
     }
     m_caeGlobalMeshSize = globalSize;
+    m_caePickNodeAction->setChecked(false);
     m_currentCaeResultField.reset();
     QString geometryFilePath;
     const Cae::CaeExternalToolConfig& config = m_caeController->externalToolConfig();
@@ -1194,6 +1177,7 @@ void MainWindow::onCaeGenerateMesh()
 
 void MainWindow::onCaeRunSolver()
 {
+    m_caePickNodeAction->setChecked(false);
     m_currentCaeResultField.reset();
     updateStatusMessage(m_caeController->runSolver(), 5000);
     refreshCaeTree();
@@ -1236,6 +1220,119 @@ void MainWindow::onCaeSetDeformationScale()
     } else {
         updateStatusMessage(tr("Select a CAE result field before setting deformation scale."), 5000);
     }
+}
+
+void MainWindow::onCaeProbeResult()
+{
+    if (!m_currentCaeResultField) {
+        updateStatusMessage(tr("Display a CAE result field before probing a node."), 5000);
+        return;
+    }
+
+    const Cae::CaeStudy* study = m_caeController->project().activeStudy();
+    if (!study || !study->result()) {
+        updateStatusMessage(tr("No CAE result is available for probing."), 5000);
+        return;
+    }
+
+    const Cae::CaeResultField* field = study->result()->field(*m_currentCaeResultField);
+    if (!field || field->nodalValues().empty()) {
+        updateStatusMessage(tr("The current result field has no nodal values."), 5000);
+        return;
+    }
+
+    const int minimumNodeId = field->nodalValues().cbegin()->first;
+    const int maximumNodeId = field->nodalValues().crbegin()->first;
+    const int initialNodeId = m_caeProbeNodeId >= minimumNodeId && m_caeProbeNodeId <= maximumNodeId
+        ? m_caeProbeNodeId
+        : minimumNodeId;
+    bool accepted = false;
+    const int nodeId = QInputDialog::getInt(
+        this,
+        tr("CAE Result Probe"),
+        tr("Node ID (%1 - %2):").arg(minimumNodeId).arg(maximumNodeId),
+        initialNodeId,
+        minimumNodeId,
+        maximumNodeId,
+        1,
+        &accepted);
+    if (!accepted) {
+        return;
+    }
+
+    showCaeNodeProbe(nodeId);
+}
+
+void MainWindow::onCaePickNodeToggled(bool enabled)
+{
+    if (enabled && !m_currentCaeResultField) {
+        const QSignalBlocker blocker(m_caePickNodeAction);
+        m_caePickNodeAction->setChecked(false);
+        updateStatusMessage(tr("Display a nodal CAE result before enabling node picking."), 5000);
+        return;
+    }
+
+    QString errorMessage;
+    if (!m_viewerWidget->setCaeNodePickingEnabled(enabled, &errorMessage)) {
+        const QSignalBlocker blocker(m_caePickNodeAction);
+        m_caePickNodeAction->setChecked(false);
+        updateStatusMessage(errorMessage, 5000);
+        return;
+    }
+
+    updateStatusMessage(
+        enabled ? tr("Node picking enabled. Click a displayed mesh node.")
+                : tr("Node picking disabled."),
+        5000);
+}
+
+void MainWindow::onCaeNodePicked(int nodeId)
+{
+    if (m_caePickNodeAction && m_caePickNodeAction->isChecked()) {
+        showCaeNodeProbe(nodeId);
+    }
+}
+
+void MainWindow::showCaeNodeProbe(int nodeId)
+{
+    if (!m_currentCaeResultField) {
+        updateStatusMessage(tr("Display a CAE result field before probing a node."), 5000);
+        return;
+    }
+
+    const Cae::CaeStudy* study = m_caeController->project().activeStudy();
+    if (!study || !study->result()) {
+        updateStatusMessage(tr("No CAE result is available for probing."), 5000);
+        return;
+    }
+
+    const Cae::CaeResultField* field = study->result()->field(*m_currentCaeResultField);
+    if (!field) {
+        updateStatusMessage(tr("The current CAE result field is unavailable."), 5000);
+        return;
+    }
+
+    const auto probe = field->probeNode(nodeId);
+    if (!probe) {
+        updateStatusMessage(tr("Node %1 has no value in the current result field.").arg(nodeId), 5000);
+        return;
+    }
+
+    m_caeProbeNodeId = nodeId;
+    QString details = tr("Node: %1\nField: %2\nValue: %3 %4")
+        .arg(probe->nodeId)
+        .arg(Cae::toDisplayString(field->type()))
+        .arg(QString::number(probe->value, 'g', 12))
+        .arg(field->unit());
+    if (probe->displacement) {
+        const auto& displacement = *probe->displacement;
+        details += tr("\nUx: %1 %4\nUy: %2 %4\nUz: %3 %4")
+            .arg(QString::number(displacement[0], 'g', 12))
+            .arg(QString::number(displacement[1], 'g', 12))
+            .arg(QString::number(displacement[2], 'g', 12))
+            .arg(field->unit());
+    }
+    QMessageBox::information(this, tr("CAE Result Probe"), details);
 }
 
 void MainWindow::presentCaeResult(Cae::ResultFieldType fieldType, bool reloadField)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -106,7 +106,6 @@ private slots:
     /* CAE */
     void onCaeNewStaticStudy();
     void onCaeNewThermalStudy();
-    void onCaeRunDemoAnalysis();
     void onCaeUseCurrentGeometry();
     void onCaeCreateNamedSelection();
     void onCaeAssignMaterial();
@@ -118,6 +117,9 @@ private slots:
     void onCaeShowStress();
     void onCaeShowTemperature();
     void onCaeSetDeformationScale();
+    void onCaeProbeResult();
+    void onCaePickNodeToggled(bool enabled);
+    void onCaeNodePicked(int nodeId);
     void onCaeSettings();
 
     /* help */
@@ -135,6 +137,7 @@ private:
     void refreshCaeTree();
     void resetCaeResultPresentation(bool preserveMesh);
     void presentCaeResult(Cae::ResultFieldType fieldType, bool reloadField = true);
+    void showCaeNodeProbe(int nodeId);
     void createThemeActions();
 
     // Ribbon creation helper functions
@@ -260,7 +263,6 @@ private:
     SARibbonPannel* m_caeSettingsPannel{};
     QAction* m_caeNewStaticAction{};
     QAction* m_caeNewThermalAction{};
-    QAction* m_caeRunDemoAnalysisAction{};
     QAction* m_caeUseCurrentGeometryAction{};
     QAction* m_caeNamedSelectionAction{};
     QAction* m_caeAssignMaterialAction{};
@@ -272,10 +274,13 @@ private:
     QAction* m_caeShowStressAction{};
     QAction* m_caeShowTemperatureAction{};
     QAction* m_caeDeformationScaleAction{};
+    QAction* m_caeProbeResultAction{};
+    QAction* m_caePickNodeAction{};
     QAction* m_caeSettingsAction{};
     double m_caeDeformationScale{0.0};
     double m_caeForceValue{100.0};
     double m_caeGlobalMeshSize{1.0};
+    int m_caeProbeNodeId{0};
     std::optional<Cae::ResultFieldType> m_currentCaeResultField;
 
 

--- a/src/ui/ViewerWidget.cpp
+++ b/src/ui/ViewerWidget.cpp
@@ -117,11 +117,14 @@
 #include <BRep_Builder.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
 #include <AIS_Shape.hxx>
+#include <AIS_Point.hxx>
 #include <AIS_InteractiveObject.hxx>
 #include <Graphic3d_ClipPlane.hxx> // Added missing include for clipping
 #include <gp_Pln.hxx>              // Added missing include for clipping
 #include <Quantity_Color.hxx>      // Added missing include for colors
 #include <gp_Vec.hxx>
+#include <Geom_CartesianPoint.hxx>
+#include <Prs3d_PointAspect.hxx>
 #include <GProp_GProps.hxx>
 #include <TDF_ChildIterator.hxx>
 
@@ -166,6 +169,7 @@
 #include <MeshVS_Mesh.hxx>
 #include <MeshVS_MeshPrsBuilder.hxx>
 #include <MeshVS_NodalColorPrsBuilder.hxx>
+#include <MeshVS_MeshSelectionMethod.hxx>
 #include <Aspect_SequenceOfColor.hxx>
 
 namespace
@@ -429,6 +433,8 @@ ViewerWidget::ViewerWidget(QWidget *parent) : QWidget(parent)
     connect(m_occView, &OCCView::signalSpaceSelected, this, &ViewerWidget::signalSpaceSelected);
     connect(m_occView, &OCCView::signalSelectedObjects, this, &ViewerWidget::signalSelectedObjects);
     connect(m_occView, &OCCView::signalSelectedObjects, this, &ViewerWidget::onUpdateSelectionInfo);
+    connect(m_occView, &OCCView::signalViewportMouseMoved, this, &ViewerWidget::onCaePickMouseMoved);
+    connect(m_occView, &OCCView::signalViewportClicked, this, &ViewerWidget::onCaePickMousePressed);
 
     connect(m_occView, &OCCView::selectionChanged, this, [this](){
         if (m_occView->Context()->NbSelected() == 0) {
@@ -571,6 +577,13 @@ bool ViewerWidget::showCaeMesh(const QString& meshFilePath, QString* errorMessag
     clearScalarField();
     clearCaeMesh();
 
+    std::map<int, gp_Pnt> pickNodes;
+    for (const auto& node : meshData.nodes) {
+        pickNodes.emplace(
+            node.first,
+            gp_Pnt(node.second[0], node.second[1], node.second[2]));
+    }
+
     Handle(Cae::OccMeshDataSource) dataSource = new Cae::OccMeshDataSource(std::move(meshData));
     Handle(MeshVS_Mesh) mesh = new MeshVS_Mesh();
     mesh->SetDataSource(dataSource);
@@ -585,12 +598,18 @@ bool ViewerWidget::showCaeMesh(const QString& meshFilePath, QString* errorMessag
 
     m_occView->Context()->Display(mesh, MeshVS_DMF_WireFrame, 0, false);
     m_doc->m_caeMesh = mesh;
+    m_caePickNodes = std::move(pickNodes);
+    if (m_caeNodePickingEnabled) {
+        setCaeNodePickingEnabled(true);
+    }
     m_occView->Context()->UpdateCurrentViewer();
     return true;
 }
 
 void ViewerWidget::clearCaeMesh()
 {
+    clearCaeNodeHover();
+    m_caePickNodes.clear();
     if (!m_doc || m_doc->m_caeMesh.IsNull()) {
         return;
     }
@@ -661,6 +680,20 @@ bool ViewerWidget::showCaeScalarField(
             : 1.0;
     }
 
+    std::map<int, gp_Pnt> pickNodes;
+    for (const auto& node : meshData.nodes) {
+        gp_Pnt point(node.second[0], node.second[1], node.second[2]);
+        const auto displacement = nodalDisplacements.find(node.first);
+        if (displacement != nodalDisplacements.end()) {
+            const auto& vector = displacement->second;
+            point.Translate(gp_Vec(
+                vector[0] * effectiveScale,
+                vector[1] * effectiveScale,
+                vector[2] * effectiveScale));
+        }
+        pickNodes.emplace(node.first, point);
+    }
+
     const double range = maximum - minimum;
     Handle(Cae::OccMeshDataSource) dataSource = new Cae::OccMeshDataSource(std::move(meshData));
     Handle(MeshVS_DataSource) displayDataSource = dataSource;
@@ -712,6 +745,10 @@ bool ViewerWidget::showCaeScalarField(
     const Standard_Integer displayMode = MeshVS_DMF_NodalColorDataPrs | MeshVS_DMF_WireFrame;
     m_occView->Context()->Display(mesh, displayMode, 0, false);
     m_doc->m_caeMesh = mesh;
+    m_caePickNodes = std::move(pickNodes);
+    if (m_caeNodePickingEnabled) {
+        setCaeNodePickingEnabled(true);
+    }
     const QString legendTitle = nodalDisplacements.empty()
         ? title
         : QStringLiteral("%1 [Deformation x%2]")
@@ -720,6 +757,142 @@ bool ViewerWidget::showCaeScalarField(
     updateCaeLegend(legendTitle, minimum, maximum);
     m_occView->Context()->UpdateCurrentViewer();
     return true;
+}
+
+bool ViewerWidget::setCaeNodePickingEnabled(bool enabled, QString* errorMessage)
+{
+    if (!m_occView || m_occView->Context().IsNull()) {
+        if (errorMessage) {
+            *errorMessage = tr("OCCT viewer is not available for node picking.");
+        }
+        return false;
+    }
+    if (!m_doc || m_doc->m_caeMesh.IsNull()) {
+        m_caeNodePickingEnabled = false;
+        if (enabled && errorMessage) {
+            *errorMessage = tr("Display a nodal CAE result before enabling node picking.");
+        }
+        return !enabled;
+    }
+
+    const Handle(MeshVS_Mesh) mesh = m_doc->m_caeMesh;
+    const auto& selectionFilters = m_occView->getSelectionFilters();
+    if (enabled) {
+        m_occView->clearSelectedObjects();
+        m_occView->Context()->ClearDetected(false);
+        for (const auto& object : m_doc->m_list) {
+            m_occView->Context()->Deactivate(object);
+        }
+    }
+
+    m_occView->Context()->Deactivate(mesh);
+    clearCaeNodeHover();
+    if (!enabled) {
+        mesh->SetMeshSelMethod(MeshVS_MSM_PRECISE);
+        mesh->UpdateSelection(0);
+        m_occView->Context()->Activate(mesh, 0, true);
+        for (const auto& object : m_doc->m_list) {
+            for (const auto& filter : selectionFilters) {
+                if (filter.second) {
+                    m_occView->Context()->Activate(
+                        object,
+                        AIS_Shape::SelectionMode(filter.first),
+                        true);
+                }
+            }
+        }
+    }
+    mesh->GetDrawer()->SetBoolean(MeshVS_DA_DisplayNodes, false);
+    m_occView->Context()->Redisplay(mesh, false);
+    m_caeNodePickingEnabled = enabled;
+
+    bool cadSelectionEnabled = false;
+    for (const auto& filter : selectionFilters) {
+        if (filter.second) {
+            cadSelectionEnabled = true;
+            break;
+        }
+    }
+    m_occView->setMouseMode(
+        enabled || cadSelectionEnabled ? View::MouseMode::SELECTION : View::MouseMode::NONE);
+    m_occView->Context()->UpdateCurrentViewer();
+    return true;
+}
+
+int ViewerWidget::findCaeNodeAt(int x, int y) const
+{
+    if (!m_caeNodePickingEnabled || !m_occView || m_occView->View().IsNull()) {
+        return -1;
+    }
+
+    constexpr int pickRadius = 10;
+    int nearestNodeId = -1;
+    int nearestDistanceSquared = pickRadius * pickRadius + 1;
+    for (const auto& node : m_caePickNodes) {
+        Standard_Integer projectedX = 0;
+        Standard_Integer projectedY = 0;
+        m_occView->View()->Convert(
+            node.second.X(), node.second.Y(), node.second.Z(), projectedX, projectedY);
+        const int dx = projectedX - x;
+        const int dy = projectedY - y;
+        const int distanceSquared = dx * dx + dy * dy;
+        if (distanceSquared < nearestDistanceSquared) {
+            nearestDistanceSquared = distanceSquared;
+            nearestNodeId = node.first;
+        }
+    }
+    return nearestNodeId;
+}
+
+void ViewerWidget::updateCaeNodeHover(int nodeId)
+{
+    if (nodeId == m_caeHoveredNodeId) {
+        return;
+    }
+    clearCaeNodeHover();
+
+    const auto node = m_caePickNodes.find(nodeId);
+    if (node == m_caePickNodes.end() || !m_occView || m_occView->Context().IsNull()) {
+        return;
+    }
+
+    m_caeNodeHoverMarker = new AIS_Point(new Geom_CartesianPoint(node->second));
+    m_caeNodeHoverMarker->SetMarker(Aspect_TOM_O_POINT);
+    m_caeNodeHoverMarker->SetColor(Quantity_NOC_YELLOW);
+    m_caeNodeHoverMarker->Attributes()->SetPointAspect(
+        new Prs3d_PointAspect(Aspect_TOM_O_POINT, Quantity_NOC_YELLOW, 3.0));
+    m_occView->Context()->Display(m_caeNodeHoverMarker, false);
+    m_occView->Context()->Deactivate(m_caeNodeHoverMarker);
+    m_caeHoveredNodeId = nodeId;
+    m_occView->Context()->UpdateCurrentViewer();
+}
+
+void ViewerWidget::clearCaeNodeHover()
+{
+    if (!m_caeNodeHoverMarker.IsNull() && m_occView && !m_occView->Context().IsNull()) {
+        m_occView->Context()->Remove(m_caeNodeHoverMarker, false);
+    }
+    m_caeNodeHoverMarker.Nullify();
+    m_caeHoveredNodeId = -1;
+}
+
+void ViewerWidget::onCaePickMouseMoved(int x, int y)
+{
+    if (m_caeNodePickingEnabled) {
+        updateCaeNodeHover(findCaeNodeAt(x, y));
+    }
+}
+
+void ViewerWidget::onCaePickMousePressed(int x, int y)
+{
+    if (!m_caeNodePickingEnabled) {
+        return;
+    }
+    const int nodeId = findCaeNodeAt(x, y);
+    if (nodeId >= 0) {
+        updateCaeNodeHover(nodeId);
+        emit signalCaeNodePicked(nodeId);
+    }
 }
 
 bool ViewerWidget::showScalarField(const QString& title, double minimum, double maximum, QString* errorMessage)
@@ -1389,7 +1562,8 @@ void ViewerWidget::setFilters(const std::map<TopAbs_ShapeEnum, bool> &filters)
             break;
         }
     }
-    m_occView->setMouseMode(anyFilterActive ? View::MouseMode::SELECTION : View::MouseMode::NONE);
+    m_occView->setMouseMode(
+        anyFilterActive || m_caeNodePickingEnabled ? View::MouseMode::SELECTION : View::MouseMode::NONE);
 
     for (const auto &pair : filters) {
         m_occView->updateSelectionFilter(pair.first, pair.second);
@@ -1410,7 +1584,8 @@ void ViewerWidget::updateSelectionFilter(TopAbs_ShapeEnum filter, bool isActive)
             break;
         }
     }
-    m_occView->setMouseMode(anyFilterActive ? View::MouseMode::SELECTION : View::MouseMode::NONE);
+    m_occView->setMouseMode(
+        anyFilterActive || m_caeNodePickingEnabled ? View::MouseMode::SELECTION : View::MouseMode::NONE);
 }
 
 void ViewerWidget::createWorkPlane()

--- a/src/ui/ViewerWidget.h
+++ b/src/ui/ViewerWidget.h
@@ -4,12 +4,13 @@
 #include <map>
 
 #include <QWidget>
+#include <AIS_Point.hxx>
+#include <gp_Pnt.hxx>
 #include <TopoDS_Shape.hxx> 
 #include <TDocStd_Document.hxx>
 #include "OCCView.h" 
 class AIS_InteractiveObject;
 class gp_Dir;
-class gp_Pnt;
 class QLabel;
 class QResizeEvent;
 
@@ -149,6 +150,7 @@ public:
         QString* errorMessage = nullptr);
     bool showScalarField(const QString& title, double minimum, double maximum, QString* errorMessage = nullptr);
     void clearScalarField();
+    bool setCaeNodePickingEnabled(bool enabled, QString* errorMessage = nullptr);
 
     void onFunctionTest();
 signals:
@@ -157,9 +159,12 @@ signals:
  //   void signalSelectedObjects(const std::vector<opencascade::handle<AIS_InteractiveObject>>& objects);
     void signalSelectedObjects(const std::vector<std::shared_ptr<View::SelectedEntity>>& objects);
     void signalSelectionInfo(const QString& info);
+    void signalCaeNodePicked(int nodeId);
 
 private slots:
     void onUpdateSelectionInfo(const std::vector<std::shared_ptr<View::SelectedEntity>>& selectedObjects);
+    void onCaePickMouseMoved(int x, int y);
+    void onCaePickMousePressed(int x, int y);
 
 public slots:
     void highlightLabel(const TDF_Label& label);
@@ -191,6 +196,9 @@ private:
     bool exportDxfToPath(const QString& savePath, QString* errorMessage);
     void hideCadGeometryForCaeResult();
     void updateCaeLegend(const QString& title, double minimum, double maximum);
+    int findCaeNodeAt(int x, int y) const;
+    void updateCaeNodeHover(int nodeId);
+    void clearCaeNodeHover();
 
 private:
     OCCView*                        m_occView{nullptr};
@@ -199,6 +207,10 @@ private:
     Handle(AIS_InteractiveObject)   m_highlightedShape{nullptr};
     bool                            m_isShowBoundingBox{true};  
     QLabel*                         m_caeLegendLabel{nullptr};
+    bool                            m_caeNodePickingEnabled{false};
+    std::map<int, gp_Pnt>           m_caePickNodes;
+    Handle(AIS_Point)               m_caeNodeHoverMarker;
+    int                             m_caeHoveredNodeId{-1};
 
     //TopoDS_Shape m_loadedShape;
 

--- a/src/ui/WidgetCaeTree.cpp
+++ b/src/ui/WidgetCaeTree.cpp
@@ -76,10 +76,12 @@ void CaeTreeWidget::addStudyItem(QTreeWidgetItem* parent, const Cae::CaeStudy& s
     auto* meshItem = new QTreeWidgetItem(studyItem, {tr("Mesh"), hasMesh ? tr("Ready") : tr("Pending")});
     if (study.mesh()) {
         const auto& mesh = *study.mesh();
-        new QTreeWidgetItem(meshItem, {tr("Global Size"), QString::number(mesh.setup().globalSize())});
+        new QTreeWidgetItem(meshItem, {tr("Maximum Element Size"), QString::number(mesh.setup().globalSize())});
         new QTreeWidgetItem(meshItem, {tr("Element Order"), Cae::toDisplayString(mesh.setup().elementOrder())});
         new QTreeWidgetItem(meshItem, {tr("Nodes"), QString::number(mesh.nodeCount())});
-        new QTreeWidgetItem(meshItem, {tr("Elements"), QString::number(mesh.elementCount())});
+        new QTreeWidgetItem(meshItem, {tr("Surface Elements"), QString::number(mesh.surfaceElementCount())});
+        new QTreeWidgetItem(meshItem, {tr("Volume Elements"), QString::number(mesh.volumeElementCount())});
+        new QTreeWidgetItem(meshItem, {tr("Supported Elements"), QString::number(mesh.elementCount())});
         new QTreeWidgetItem(meshItem, {tr("Source"), mesh.source()});
     }
 
@@ -104,6 +106,7 @@ void CaeTreeWidget::addStudyItem(QTreeWidgetItem* parent, const Cae::CaeStudy& s
             auto* fieldItem = new QTreeWidgetItem(resultsItem, {Cae::toDisplayString(field.type()), field.unit()});
             new QTreeWidgetItem(fieldItem, {tr("Min"), QString::number(field.minValue())});
             new QTreeWidgetItem(fieldItem, {tr("Max"), QString::number(field.maxValue())});
+            new QTreeWidgetItem(fieldItem, {tr("Nodal Values"), QString::number(static_cast<qulonglong>(field.nodalValues().size()))});
             new QTreeWidgetItem(fieldItem, {tr("Source"), field.source()});
         }
     }


### PR DESCRIPTION
feat: enhance CAE mesh and result node picking

1. Improve mesh sizing, element statistics, FRD result parsing, and deformation display.
2. Add node hover highlighting, screen-space picking, and result probing.
3. Remove the CAE Demo entry and update Ribbon icons and development documentation.

